### PR TITLE
Dev.html ahora apunta a Mapea 5.1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,11 +68,6 @@ M.language.setLang('en');//Idioma inglés
 ```
 Se pueden crear más ficheros de idioma. Basta con copiar la estructura de los ficheros **json** de la carpeta *\src\facade\js\i18n* , renombrar con la abreviatura del nuevo idioma (fr para el fránces), y cambiar los textos, manteniendo las *keywords*.
 
-
-# Otros métodos
-
-No aplica
-
 # Ejemplos de uso
 
 ## Ejemplo 1

--- a/test/dev.html
+++ b/test/dev.html
@@ -7,8 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="mapea" content="yes">
     <title>Layer Comparison Test</title>
-    <link href="http://sigc-dev.desarrollo.guadaltel.es/mapea5/assets/css/mapea-5.2.0.ol.min.css" rel="stylesheet" />
-    <link href="../dist/lyrcompare.ol.min.css" rel="stylesheet" />
+    <link href="http://mapea4-sigc.juntadeandalucia.es/mapea/assets/css/mapea-5.1.0.ol.min.css" rel="stylesheet" />
     <style rel="stylesheet">
         html,
         body {
@@ -23,39 +22,10 @@
 
 <body>
     <div id="mapjs" class="container"></div>
-    <script type="text/javascript"
-        src="http://sigc-dev.desarrollo.guadaltel.es/mapea5/js/mapea-5.2.0.ol.min.js"></script>
-    <script type="text/javascript"
-        src="http://sigc-dev.desarrollo.guadaltel.es/mapea5/js/configuration-5.2.0.js"></script>
+    <script type="text/javascript" src="http://mapea4-sigc.juntadeandalucia.es/mapea/js/mapea-5.1.0.ol.min.js"></script>
+    <script type="text/javascript" src="http://mapea4-sigc.juntadeandalucia.es/mapea/js/configuration-5.1.0.js"></script>
     <script type="text/javascript" src="../dist/lyrcompare.ol.min.js"></script>
-    <script type="text/javascript">
-        const map = M.map({
-            container: 'mapjs',
-        });
-        const mp = new M.plugin.LyrCompare({
-            position: 'TL',
-            layers: [
-                'WMS*SIGPAC*https://www.ign.es/wms/pnoa-historico*SIGPAC',
-                'WMS*OLISTAT*https://www.ign.es/wms/pnoa-historico*OLISTAT',
-                'WMS*Nacional_1981-1986*https://www.ign.es/wms/pnoa-historico*Nacional_1981-1986',
-                'WMS*Interministerial_1973-1986*https://www.ign.es/wms/pnoa-historico*Interministerial_1973-1986',
-                'WMS*Redes*http://www.ideandalucia.es/wms/mta400v_2008?*Redes_energeticas',
-                'WMS*AMS_1956-1957*https://www.ign.es/wms/pnoa-historico*AMS_1956-1957',
-                'WMS*pnoa2006*https://www.ign.es/wms/pnoa-historico*pnoa2006',
-            ],
-            collapsible: true,
-            collapsed: true,
-            staticDivision: 1,
-            opacityVal: 100,
-            comparisonMode: 0,
-            defaultLyrA: 0,
-            defaultLyrB: 1,
-            defaultLyrC: 2,
-            defaultLyrD: 3,
-            interface: true,
-        });
-        map.addPlugin(mp);
-    </script>
+    <script type="text/javascript" src="/main.js"></script>
 </body>
 
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,16 @@ const map = M.map({
 M.language.setLang('es'); //Español
 //M.language.setLang('en');//Inglés
 
+const mp = new M.plugin.LyrCompare({
+  layers: [
+      'WMTS*http://www.ideandalucia.es/geowebcache/service/wmts?*orto_2010-11',
+      'WMTS*http://www.ideandalucia.es/geowebcache/service/wmts?*toporaster',
+      'WMTS*http://www.callejerodeandalucia.es/servicios/base/gwc/service/wmts?*SPOT_Andalucia',
+      'WMTS*http://www.callejerodeandalucia.es/servicios/base/gwc/service/wmts?*base',
+  ],
+});
+map.addPlugin(mp);
+
 /**
  * Ejemplo 1
  * Insertar capas WMS con formato Mapea.
@@ -14,7 +24,7 @@ M.language.setLang('es'); //Español
  * El modo de división es 1 por lo que será estático.
  * La interfaz está activa.
  */
-const pluginLyrCompare = new LyrCompare({
+/* const pluginLyrCompare = new LyrCompare({
   position: 'TL',
   layers: [
     'WMS*SIGPAC*https://www.ign.es/wms/pnoa-historico*SIGPAC',
@@ -30,7 +40,8 @@ const pluginLyrCompare = new LyrCompare({
   interface: true,
 });
 
-
+map.addPlugin(pluginLyrCompare);
+*/
 /**
  * Ejemplo 2
  * Al no indicar capas mostrará un error en pantalla: El número de capas es insuficiente para aplicar el efecto


### PR DESCRIPTION
Corregidos los enlaces de dev.html para que apunte a la versión 5.1 de Mapea.